### PR TITLE
Fix #5: Make main banner title clickable to /help

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,10 +2,12 @@ export default function HomePage() {
   return (
     <main className="pageMain">
       <div className="card heroCard">
-        <h1 className="heroTitle">리뷰로 매출 올릴 포인트, 자동으로 뽑아드립니다</h1>
-        <p className="heroLead">
-          CSV로 리뷰를 올리면, 자주 나오는 불만(키워드/카테고리)과 상세페이지/CS/FAQ 문구를 바로 쓸 수 있게 정리해줍니다.
-        </p>
+        <a href="/help" style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}>
+          <h1 className="heroTitle">리뷰로 매출 올릴 포인트, 자동으로 뽑아드립니다</h1>
+          <p className="heroLead">
+            CSV로 리뷰를 올리면, 자주 나오는 불만(키워드/카테고리)과 상세페이지/CS/FAQ 문구를 바로 쓸 수 있게 정리해줍니다.
+          </p>
+        </a>
         <div className="actionRow actionRowLg">
           <a className="btn btnPrimary" href="/dashboard">
             CSV 올리고 분석하기
@@ -45,7 +47,7 @@ export default function HomePage() {
             가입이나 설정 없이도 분석은 바로 가능합니다. (저장 기능은 로그인 기능을 켜면 사용할 수 있어요.)
           </p>
           <p className="muted">
-            CSV 헤더는 어떤 이름이어도 괜찮습니다. 업로드 후 화면에서 “리뷰 내용/별점/작성일” 열만 선택해주면 됩니다.
+            CSV 헤더는 어떤 이름이어도 괜찮습니다. 업로드 후 화면에서 &quot;리뷰 내용/별점/작성일&quot; 열만 선택해주면 됩니다.
           </p>
           <div className="actionRow">
             <a className="btn" href="/sample.csv" download>


### PR DESCRIPTION
## Problem
Issue #5: 메인배너 클릭하면 /help로 이동하기

메인배너(heroCard)의 제목과 설명 텍스트가 클릭 불가능했습니다.

## Root Cause
heroCard 내부의 title과 lead text가 링크로 감싸져 있지 않았습니다.

## Changes Made
- 메인배너의 title과 lead text를 `<a href="/help">`로 감싸서 클릭 가능하게 함
- 기존 버튼 기능(/dashboard, /help)은 그대로 유지

## Validation
- `npm run lint` ✅ 통과

## Risk Assessment
- **Low Risk**: 단순 UI 변경, 기존 기능 보존

Closes #5