### PR TITLE
fix: Improve OTP expired error handling with clear action buttons

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,19 +9,39 @@ export default function HomePage(props: { searchParams?: Record<string, string |
 
   // Build friendly error message based on error code
   let errorMessage = err;
+  let showResendOption = false;
   if (errCode === "otp_expired" || errDesc.includes("expired")) {
     errorMessage = "이메일 인증 링크가 만료되었습니다. 다시 회원가입을 시도해주세요.";
+    showResendOption = true;
   } else if (errCode === "access_denied") {
     errorMessage = "이메일 인증에 실패했습니다. 링크가 이미 사용되었거나 유효하지 않을 수 있습니다.";
+    showResendOption = true;
   } else if (errDesc) {
     // Use error_description if available
     errorMessage = errDesc.replace(/\+/g, ' ');
   }
 
+  const isErrorState = !!errorMessage;
+
   return (
     <main className="pageMain">
-      {errorMessage ? <FeedbackModal title="오류" message={errorMessage} tone="error" /> : null}
-      {!errorMessage && notice ? <FeedbackModal title="안내" message={notice} /> : null}
+      {isErrorState && (
+        <div className="card" style={{ marginBottom: '2rem', borderColor: '#dc3545', backgroundColor: '#fff5f5' }}>
+          <h2 style={{ color: '#dc3545', marginTop: 0 }}>⚠️ 인증 실패</h2>
+          <p style={{ fontSize: '1.1rem', marginBottom: '1.5rem' }}>{errorMessage}</p>
+          {showResendOption && (
+            <div className="actionRow">
+              <a className="btn btnPrimary" href="/signup">
+                다시 가입하기
+              </a>
+              <a className="btn" href="/help">
+                도움말 보기
+              </a>
+            </div>
+          )}
+        </div>
+      )}
+      {!isErrorState && notice ? <FeedbackModal title="안내" message={notice} /> : null}
       <div className="card heroCard">
         <a href="/help" style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}>
           <h1 className="heroTitle">리뷰로 매출 올릴 포인트, 자동으로 뽑아드립니다</h1>


### PR DESCRIPTION
## Summary

Fixes issue #3: 인증메일 클릭시 만료된 경우 빈페이지만 보여지는 문제

## Changes

- Show persistent error card instead of dismissible modal
- Add '다시 가입하기' (Try again) button linking to /signup for expired/invalid links
- Add '도움말 보기' (Help) button for navigation
- Error state is now persistent on the page, not hidden when modal is closed

## Before
When OTP expired, user saw an error modal that could be closed, leaving just the normal homepage with no context about what happened.

## After  
User sees a prominent error card with clear explanation and action buttons to either retry signup or view help.