### PR TITLE
fix: PKCE 이메일 인증 오류 수정 및 favicon 로고 통일

### DIFF
--- a/src/app/auth/confirm/route.ts
+++ b/src/app/auth/confirm/route.ts
@@ -38,18 +38,12 @@ export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url);
   const tokenHash = requestUrl.searchParams.get("token_hash");
   const type = requestUrl.searchParams.get("type");
+  const code = requestUrl.searchParams.get("code");
   const next = safeNextPath(requestUrl.searchParams.get("next"), "/dashboard");
 
   const baseUrl = getBaseUrl(request);
   const loginUrl = new URL("/login", baseUrl);
   loginUrl.searchParams.set("next", next);
-
-  if (!tokenHash || !type || !OTP_TYPES.has(type as EmailOtpType)) {
-    loginUrl.searchParams.set("error", "유효하지 않은 이메일 인증 링크입니다.");
-    const res = NextResponse.redirect(loginUrl);
-    applySecurityHeaders(res.headers);
-    return res;
-  }
 
   const secureContext = requestUrl.protocol === "https:" || process.env.NODE_ENV === "production";
   let response = NextResponse.next({ request });
@@ -67,6 +61,29 @@ export async function GET(request: NextRequest) {
       }
     }
   });
+
+  // PKCE flow: Supabase redirects with ?code= instead of ?token_hash=
+  if (code) {
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (error) {
+      loginUrl.searchParams.set("error", "이메일 인증에 실패했습니다. 링크가 만료되었거나 이미 사용되었을 수 있습니다.");
+      const res = NextResponse.redirect(loginUrl);
+      applySecurityHeaders(res.headers);
+      return res;
+    }
+    loginUrl.searchParams.set("notice", "이메일 인증이 완료되었습니다. 로그인해주세요.");
+    const res = NextResponse.redirect(loginUrl);
+    applySecurityHeaders(res.headers);
+    return res;
+  }
+
+  // OTP flow: token_hash + type
+  if (!tokenHash || !type || !OTP_TYPES.has(type as EmailOtpType)) {
+    loginUrl.searchParams.set("error", "유효하지 않은 이메일 인증 링크입니다.");
+    const res = NextResponse.redirect(loginUrl);
+    applySecurityHeaders(res.headers);
+    return res;
+  }
 
   const { error } = await supabase.auth.verifyOtp({
     type: type as EmailOtpType,

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,13 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#2563eb"/>
-      <stop offset="100%" stop-color="#0ea5e9"/>
-    </linearGradient>
-  </defs>
-  <rect width="512" height="512" rx="96" fill="url(#bg)"/>
-  <text x="256" y="280" text-anchor="middle" dominant-baseline="central"
-        font-family="Arial,Helvetica,sans-serif" font-weight="800"
-        font-size="240" fill="#ffffff" letter-spacing="-8">RB</text>
-  <path d="M380 340 L420 310 L420 370 Z" fill="rgba(255,255,255,0.5)"/>
+  <rect width="512" height="512" rx="96" fill="#111111"/>
+  <circle cx="256" cy="256" r="192" fill="none" stroke="#ffffff" stroke-width="24"/>
+  <path d="M138 308 230 249l78 40 94-101" fill="none" stroke="#ffffff" stroke-width="30" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="231" cy="249" r="22" fill="#ffffff"/>
+  <circle cx="369" cy="189" r="22" fill="#ffffff"/>
+  <circle cx="139" cy="308" r="22" fill="#ffffff"/>
 </svg>


### PR DESCRIPTION
## Summary
- **이메일 인증 버그 수정**: Supabase PKCE 플로우 사용 시 `/auth/confirm`에 `code` 파라미터가 오면 \"유효하지 않은 링크\" 오류가 발생하던 문제 해결 — `exchangeCodeForSession()` 처리 분기 추가
- **Favicon 업데이트**: 기존 파란 그라디언트 \"RB\" 텍스트에서 사이드바 로고와 동일한 원형 꺾은선 그래프 아이콘으로 변경

## Test Plan
- [ ] 신규 이메일로 회원가입 후 인증 메일 링크 클릭 → 에러 없이 로그인 페이지로 이동하는지 확인
- [ ] 브라우저 탭에서 새 favicon 아이콘 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)