### PR TITLE
refactor(wave1): Paddle webhook idempotency + OpenAI token logging

### DIFF
--- a/src/app/api/billing/webhook/route.ts
+++ b/src/app/api/billing/webhook/route.ts
@@ -1,4 +1,4 @@
-﻿import { findUserIdByPaddleCustomerId, upsertProfileCustomer, upsertSubscription } from "@/lib/billing";
+﻿import { claimPaddleWebhookEvent, findUserIdByPaddleCustomerId, upsertProfileCustomer, upsertSubscription } from "@/lib/billing";
 import { paddlePlanForPriceId } from "@/lib/paddle";
 import {
   extractCustomerId,
@@ -249,6 +249,13 @@ export async function POST(req: Request) {
     const type = String(event?.event_type ?? "");
     const eventId = String(event?.event_id ?? "").trim() || null;
     const data = event.data;
+
+    if (eventId) {
+      const claimed = await claimPaddleWebhookEvent(eventId, type);
+      if (!claimed) {
+        return Response.json({ received: true, duplicate: true });
+      }
+    }
 
     if (type === "transaction.completed" || type === "order.completed") {
       await handleEntitlementEvent(type, eventId, data);

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -182,6 +182,28 @@ export async function findPaddleCustomerIdByUserId(userId: string): Promise<stri
   return id || null;
 }
 
+/**
+ * Attempts to claim a Paddle webhook event by inserting its event_id.
+ * Returns true if the event is new (should be processed), false if already seen.
+ * Returns true when Supabase is not configured (fail-open to avoid blocking prod).
+ */
+export async function claimPaddleWebhookEvent(eventId: string, eventType: string): Promise<boolean> {
+  const admin = getSupabaseAdminClient();
+  if (!admin) return true;
+
+  const { error } = await admin.from("paddle_webhook_events").insert({
+    event_id: eventId,
+    event_type: eventType,
+    received_at: new Date().toISOString()
+  });
+
+  if (!error) return true;
+  // PostgreSQL unique-violation code — event already processed
+  if ((error as { code?: string }).code === "23505") return false;
+  // On unexpected errors, fail-open rather than blocking the webhook
+  return true;
+}
+
 export async function upsertSubscription(args: {
   userId: string;
   paddleSubscriptionId: string;

--- a/src/lib/openai_classify.ts
+++ b/src/lib/openai_classify.ts
@@ -188,6 +188,14 @@ export async function classifyReviewsWithOpenAI(args: {
       return;
     }
 
+    if (resp.usage) {
+      console.log(
+        `[LLM:classify][TOKEN_USAGE] model=${model}, batchOffset=${offset}, ` +
+        `prompt=${resp.usage.prompt_tokens}, completion=${resp.usage.completion_tokens}, ` +
+        `total=${resp.usage.total_tokens}`
+      );
+    }
+
     const text = resp.choices?.[0]?.message?.content ?? "";
     const parsedItems = parseOpenAiResponse(text);
     if (!parsedItems) {

--- a/src/lib/openai_suggestions.ts
+++ b/src/lib/openai_suggestions.ts
@@ -213,6 +213,14 @@ export async function generateSuggestions(stats: AnalysisStats, opts?: Suggestio
     return fallbackSuggestions(stats, opts);
   }
 
+  if (resp.usage) {
+    console.log(
+      `[LLM:suggest][TOKEN_USAGE] model=${model}, ` +
+      `prompt=${resp.usage.prompt_tokens}, completion=${resp.usage.completion_tokens}, ` +
+      `total=${resp.usage.total_tokens}`
+    );
+  }
+
   const text = resp.choices?.[0]?.message?.content ?? "";
   try {
     const parsed = JSON.parse(text) as SuggestionRaw;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -176,3 +176,14 @@ on public.subscriptions
 for select
 to authenticated
 using (user_id = auth.uid());
+
+-- Paddle webhook idempotency: deduplicates events by provider event_id.
+-- Service role only — no user-facing RLS needed.
+create table if not exists public.paddle_webhook_events (
+  event_id text primary key,
+  event_type text not null,
+  received_at timestamptz not null default now()
+);
+
+create index if not exists paddle_webhook_events_received_at_idx
+  on public.paddle_webhook_events (received_at);


### PR DESCRIPTION
## Summary

- **Paddle webhook idempotency**: `paddle_webhook_events` 테이블(event_id PK) 추가 + `claimPaddleWebhookEvent()` 함수. 중복 webhook 도착 시 early return, Supabase 미설정 시 fail-open
- **OpenAI 토큰 사용량 로깅**: `openai_classify.ts`, `openai_suggestions.ts` 각 completion 호출 후 `prompt/completion/total` 토큰 수를 `[TOKEN_USAGE]` 로그로 출력

## Changed Files

- `supabase/schema.sql` — `paddle_webhook_events` 테이블 + index 추가
- `src/lib/billing.ts` — `claimPaddleWebhookEvent()` 함수 추가
- `src/app/api/billing/webhook/route.ts` — 멱등성 체크 로직 추가
- `src/lib/openai_classify.ts` — TOKEN_USAGE 로그 추가
- `src/lib/openai_suggestions.ts` — TOKEN_USAGE 로그 추가

## Test plan

- [ ] Supabase에 `paddle_webhook_events` 마이그레이션 실행
- [ ] Paddle webhook 동일 이벤트 재전송 시 `duplicate: true` 응답 확인
- [ ] OpenAI 분류 실행 후 서버 로그에서 `[TOKEN_USAGE]` 확인

https://claude.ai/code/session_01TrUAJS8Mi8DRV66FrUuAWX