### PR TITLE
feat(seo): 마케팅 페이지 정적화 + JSON-LD·robots·llms.txt 개선

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ There is no test suite. CI (`.github/workflows/ci.yml`) runs: `npm ci` → `lint
 
 ## Tech Stack
 
-- **Next.js 14** with App Router, React 18, TypeScript 5 (strict mode)
+- **Next.js 15** with App Router, React 18, TypeScript 5 (strict mode)
 - **Supabase** for auth, database, and RLS policies (optional — app degrades gracefully without it)
 - **OpenAI API** (gpt-4o-mini) for LLM classification and suggestions (optional — falls back to heuristic/template)
 - **Paddle** for subscription billing (optional)
@@ -69,7 +69,7 @@ Every external dependency is optional. The app works without OpenAI (template su
 
 ### Subscription & Plan Tiers
 
-Resolution order: env-based email overrides → Paddle subscription status in Supabase → default Free. Plans: Free (100 analyses/month), Basic (500), Pro (1500). Monthly limits enforced in `/api/analyze`.
+Resolution order: env-based email overrides → Paddle subscription status in Supabase → default Free. Plans: Free (5 analyses/month), Basic (200), Pro (1000) — source of truth in `src/lib/plan_gates.ts`. Monthly limits enforced in `/api/analyze`.
 
 ### Database
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -93,7 +93,7 @@ export default async function BlogDetailPage(props: BlogDetailPageProps) {
 
   return (
     <main className="pageMain pb-8 pt-8 md:pt-12">
-      {record ? <StructuredData data={createArticleStructuredData(record)} /> : null}
+      {record ? <StructuredData data={createArticleStructuredData(record, { image: post.image })} /> : null}
       <ShellContainer className="max-w-[980px] space-y-6">
         <nav className="text-sm text-[var(--rb-muted-strong)]">
           <Link href="/blog">← 블로그</Link>
@@ -103,6 +103,9 @@ export default async function BlogDetailPage(props: BlogDetailPageProps) {
           <span className="text-[11px] uppercase tracking-[0.22em] text-[var(--rb-accent)]">{post.tag}</span>
           <h1 className="mt-4 text-[clamp(2.2rem,4vw,4rem)] font-semibold tracking-[-0.06em] text-[var(--rb-fg)]">{post.title}</h1>
           <p className="mt-5 text-base leading-8 text-[var(--rb-muted-strong)]">{post.summary}</p>
+          {record ? (
+            <p className="mt-4 text-xs text-[var(--rb-muted)]">최종 업데이트: {record.updatedAt} · ReviewBoost 팀</p>
+          ) : null}
         </section>
 
         {post.image ? (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+import { Suspense } from "react";
 import type { Metadata } from "next";
 import Script from "next/script";
 import { ClerkProvider } from "@clerk/nextjs";
@@ -10,7 +11,6 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import AppShell from "@/components/AppShell";
 import StructuredData from "@/components/seo/StructuredData";
 import { I18nProvider } from "@/lib/i18n";
-import { getNavigationSessionState } from "@/lib/navigation_session";
 import { paddleBrowserEnv, paddleBrowserToken } from "@/lib/paddle";
 import { getBaseUrl } from "@/lib/seo/metadata";
 import { createGlobalStructuredData } from "@/lib/seo/structured-data";
@@ -33,13 +33,11 @@ export const metadata: Metadata = {
   }
 };
 
-export const dynamic = "force-dynamic";
 const paddleToken = paddleBrowserToken();
 const paddleEnvForClient = paddleBrowserEnv();
 const isVercelDeployment = Boolean(process.env.VERCEL || process.env.VERCEL_ENV);
 
-export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const session = await getNavigationSessionState();
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   const clerkKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 
   const body = (
@@ -63,13 +61,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <ErrorBoundary>
           {isVercelDeployment ? <Analytics /> : null}
           {isVercelDeployment ? <SpeedInsights /> : null}
-          <GoogleAnalytics />
-          <AnalyticsQueryEvents />
-          <AssistantAttributionEvents />
+          <Suspense fallback={null}>
+            <GoogleAnalytics />
+            <AnalyticsQueryEvents />
+            <AssistantAttributionEvents />
+          </Suspense>
           <I18nProvider>
-            <AppShell plan={session.plan} userEmail={session.userEmail}>
-              {children}
-            </AppShell>
+            <AppShell>{children}</AppShell>
           </I18nProvider>
         </ErrorBoundary>
       </body>

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,4 +1,6 @@
 import { getBaseUrl } from "@/lib/seo/metadata";
+import { getGatesForPlan } from "@/lib/plan_gates";
+import { blogPosts } from "@/lib/blog-posts";
 
 export function GET() {
   const baseUrl = getBaseUrl();
@@ -22,6 +24,14 @@ export function GET() {
     `- Smart Store CSV guide: ${baseUrl}/help/smartstore-review-csv-export`,
     `- Review CSV tool: ${baseUrl}/coupang-csv`,
     `- Blog: ${baseUrl}/blog`,
+    ``,
+    `## Blog guides`,
+    ...blogPosts.map((post) => `- ${post.title}: ${baseUrl}/blog/${post.slug}`),
+    ``,
+    `## Plans`,
+    `- Starter (free): ${getGatesForPlan("free").monthlyAnalysisLimit} review analyses per month`,
+    `- Basic (KRW 19,000/month): ${getGatesForPlan("basic").monthlyAnalysisLimit} review analyses per month`,
+    `- Pro (KRW 45,000/month): ${getGatesForPlan("pro").monthlyAnalysisLimit} review analyses per month`,
     ``,
     `## Product facts`,
     `- Upload review CSV files and confirm columns before analysis`,

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -5,34 +5,16 @@ import PricingContent from "@/components/PricingContent";
 import { generatePageMetadata } from "@/lib/seo/metadata";
 import { getRequiredSeoPageRecord } from "@/lib/seo/page-registry";
 import { createPricingStructuredData } from "@/lib/seo/structured-data";
-import { auth } from "@clerk/nextjs/server";
 
 const pricingRecord = getRequiredSeoPageRecord("/pricing");
 
 export const metadata: Metadata = generatePageMetadata(pricingRecord);
 
-export default async function PricingPage({
-  searchParams
-}: {
-  searchParams?: Promise<{ billing?: string; [key: string]: string | string[] | undefined }>;
-}) {
-  let userId: string | null = null;
-
-  try {
-    if (process.env.CLERK_SECRET_KEY) {
-      const result = await auth();
-      userId = result.userId ?? null;
-    }
-  } catch {
-    // ignore and keep unauthenticated state
-  }
-
-  const billing = (await searchParams)?.billing;
-
+export default function PricingPage() {
   return (
     <>
       <StructuredData data={createPricingStructuredData(pricingRecord)} />
-      <PricingContent userId={userId} billing={billing} />
+      <PricingContent />
     </>
   );
 }

--- a/src/app/robots.txt/route.ts
+++ b/src/app/robots.txt/route.ts
@@ -9,9 +9,6 @@ export function GET() {
     `Disallow: /api/`,
     `Disallow: /dashboard/`,
     `Disallow: /auth/`,
-    `Disallow: /login`,
-    `Disallow: /signup`,
-    `Disallow: /reset-password`,
     `Sitemap: ${baseUrl}/sitemap.xml`
   ].join("\n");
 

--- a/src/components/AppShell.test.tsx
+++ b/src/components/AppShell.test.tsx
@@ -100,6 +100,25 @@ describe("AppShell", () => {
     expect(screen.getAllByRole("complementary", { name: "주요 메뉴" }).length).toBe(1);
   });
 
+  it("switches the header to the dashboard link once the session fetch resolves", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ authenticated: true, plan: "basic", userEmail: "tester@example.com" })
+      })
+    );
+
+    renderWithI18n(
+      <AppShell>
+        <div>내용</div>
+      </AppShell>
+    );
+
+    expect(await screen.findByRole("link", { name: "대시보드" })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "로그인" })).toBeNull();
+  });
+
   it("removes the marketing chrome on auth routes", () => {
     mockPathname = "/login";
 

--- a/src/components/AppShell.test.tsx
+++ b/src/components/AppShell.test.tsx
@@ -40,17 +40,19 @@ describe("AppShell", () => {
       writable: true,
       value: 1440
     });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
   });
 
   afterEach(() => {
     cleanup();
+    vi.unstubAllGlobals();
     mockPathname = "/pricing";
     document.body.className = "";
   });
 
   it("renders the marketing header and footer on public pages", () => {
     renderWithI18n(
-      <AppShell userEmail="tester@example.com" plan="basic">
+      <AppShell>
         <div>내용</div>
       </AppShell>
     );
@@ -65,7 +67,7 @@ describe("AppShell", () => {
     mockPathname = "/dashboard";
 
     renderWithI18n(
-      <AppShell userEmail="tester@example.com" plan="basic">
+      <AppShell>
         <div>대시보드 내용</div>
       </AppShell>
     );
@@ -84,7 +86,7 @@ describe("AppShell", () => {
     window.innerWidth = 900;
 
     renderWithI18n(
-      <AppShell userEmail="tester@example.com" plan="basic">
+      <AppShell>
         <div>대시보드 내용</div>
       </AppShell>
     );
@@ -102,7 +104,7 @@ describe("AppShell", () => {
     mockPathname = "/login";
 
     renderWithI18n(
-      <AppShell userEmail={null} plan="free">
+      <AppShell>
         <div>로그인 화면</div>
       </AppShell>
     );

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -228,7 +228,7 @@ export default function AppShell({ children }: AppShellProps) {
     return () => {
       active = false;
     };
-  }, []);
+  }, [pathname]);
 
   useEffect(() => {
     const updateDeviceMode = () => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -11,8 +11,6 @@ import type { PlanTier } from "@/types/user";
 
 type AppShellProps = {
   children: React.ReactNode;
-  userEmail?: string | null;
-  plan?: PlanTier;
 };
 
 type ChromeConfig = {
@@ -201,12 +199,36 @@ function MarketingFooter() {
   );
 }
 
-export default function AppShell({ children, userEmail = null, plan = "free" }: AppShellProps) {
+export default function AppShell({ children }: AppShellProps) {
   const pathname = usePathname();
   const config = useMemo(() => getChromeConfig(pathname), [pathname]);
   const [isMobile, setIsMobile] = useState(false);
   const [open, setOpen] = useState(false);
+  const [plan, setPlan] = useState<PlanTier>("free");
+  const [userEmail, setUserEmail] = useState<string | null>(null);
   const drawerFirstLinkRef = useRef<HTMLAnchorElement | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    fetch("/api/navigation-session", { cache: "no-store", credentials: "same-origin" })
+      .then(async (res) => {
+        if (!res.ok) return null;
+        return (await res.json()) as { plan?: PlanTier; userEmail?: string | null } | null;
+      })
+      .then((session) => {
+        if (!active || !session) return;
+        setPlan(session.plan === "basic" || session.plan === "pro" ? session.plan : "free");
+        setUserEmail(typeof session.userEmail === "string" ? session.userEmail : null);
+      })
+      .catch(() => {
+        // Public shell falls back to guest mode when auth lookup is unavailable.
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   useEffect(() => {
     const updateDeviceMode = () => {

--- a/src/components/PricingActions.test.tsx
+++ b/src/components/PricingActions.test.tsx
@@ -54,7 +54,7 @@ describe("PricingActions", () => {
       })
     );
 
-    render(<PricingActions plan="basic" userId="usr_123" />);
+    render(<PricingActions plan="basic" />);
 
     fireEvent.click(screen.getByRole("button", { name: "Basic 시작하기" }));
 
@@ -83,7 +83,7 @@ describe("PricingActions", () => {
       })
     );
 
-    render(<PricingActions plan="pro" userId="usr_123" />);
+    render(<PricingActions plan="pro" />);
 
     fireEvent.click(screen.getByRole("button", { name: "Pro 시작하기" }));
 
@@ -103,7 +103,7 @@ describe("PricingActions", () => {
       })
     );
 
-    render(<PricingActions plan="basic" userId="usr_123" />);
+    render(<PricingActions plan="basic" />);
 
     fireEvent.click(screen.getByRole("button", { name: "Basic 시작하기" }));
 
@@ -123,7 +123,7 @@ describe("PricingActions", () => {
       })
     );
 
-    render(<PricingActions plan="pro" userId="usr_123" />);
+    render(<PricingActions plan="pro" />);
 
     fireEvent.click(screen.getByRole("button", { name: "Pro 시작하기" }));
 
@@ -135,16 +135,4 @@ describe("PricingActions", () => {
     expect(paddleOpenMock).not.toHaveBeenCalled();
   });
 
-  it("shows auth error before calling the server when user is not signed in", async () => {
-    render(<PricingActions plan="pro" />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Pro 시작하기" }));
-
-    await waitFor(() => {
-      expect(screen.getByRole("alert").textContent ?? "").toContain("로그인이 필요합니다.");
-    });
-
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(assignMock).not.toHaveBeenCalled();
-  });
 });

--- a/src/components/PricingActions.test.tsx
+++ b/src/components/PricingActions.test.tsx
@@ -95,6 +95,26 @@ describe("PricingActions", () => {
     expect(paddleOpenMock).not.toHaveBeenCalled();
   });
 
+  it("shows login-required error when middleware returns a plain-text 401", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("Unauthorized", {
+        status: 401,
+        headers: { "content-type": "text/plain" }
+      })
+    );
+
+    render(<PricingActions plan="basic" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Basic 시작하기" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent ?? "").toContain("로그인이 필요합니다.");
+    });
+
+    expect(assignMock).not.toHaveBeenCalled();
+    expect(paddleOpenMock).not.toHaveBeenCalled();
+  });
+
   it("shows configuration error returned by the checkout api", async () => {
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ error: "결제 설정이 아직 완료되지 않았습니다." }), {

--- a/src/components/PricingActions.tsx
+++ b/src/components/PricingActions.tsx
@@ -42,6 +42,11 @@ export default function PricingActions({ plan }: Props) {
         payload = null;
       }
 
+      if (response.status === 401) {
+        // Clerk middleware returns a plain-text 401 before the route's JSON runs
+        throw new Error("로그인이 필요합니다. 로그인 후 다시 시도해 주세요.");
+      }
+
       if (!response.ok) {
         throw new Error(String(payload?.error || "결제 세션 생성 중 오류가 발생했습니다."));
       }

--- a/src/components/PricingActions.tsx
+++ b/src/components/PricingActions.tsx
@@ -6,7 +6,6 @@ import { getErrorMessage } from "@/types/common";
 
 type Props = {
   plan: "basic" | "pro";
-  userId?: string;
 };
 
 type CheckoutResponse = {
@@ -14,7 +13,7 @@ type CheckoutResponse = {
   error?: string;
 };
 
-export default function PricingActions({ plan, userId }: Props) {
+export default function PricingActions({ plan }: Props) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -28,10 +27,6 @@ export default function PricingActions({ plan, userId }: Props) {
     setBusy(true);
     setError(null);
     try {
-      if (!userId) {
-        throw new Error("로그인이 필요합니다.");
-      }
-
       const response = await fetch("/api/billing/checkout", {
         method: "POST",
         headers: {

--- a/src/components/PricingContent.test.tsx
+++ b/src/components/PricingContent.test.tsx
@@ -6,8 +6,13 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/i18n", () => ({
   useTranslation: () => ({
-    t: (key: string) => key
+    t: (key: string) => key,
+    locale: "ko"
   })
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams()
 }));
 
 vi.mock("@/components/PricingActions", () => ({
@@ -18,7 +23,7 @@ import PricingContent from "./PricingContent";
 
 describe("PricingContent", () => {
   it("does not render a duplicate paddle script tag", () => {
-    const { container } = render(<PricingContent userId="usr_123" billing={undefined} />);
+    const { container } = render(<PricingContent />);
 
     expect(container.querySelector('script[src="https://cdn.paddle.com/paddle/v2/paddle.js"]')).toBeNull();
   });

--- a/src/components/PricingContent.tsx
+++ b/src/components/PricingContent.tsx
@@ -1,25 +1,48 @@
 "use client";
 
-import React from "react";
+import React, { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import PricingActions from "@/components/PricingActions";
 import { SectionHeader, ShellContainer, Surface } from "@/components/ui/Primitives";
 import { getSiteContent } from "@/lib/site-content";
+import { getGatesForPlan } from "@/lib/plan_gates";
 import { useTranslation } from "@/lib/i18n";
 
-interface PricingContentProps {
-  userId: string | null;
-  billing: string | undefined;
+function BillingNotice() {
+  const billing = useSearchParams().get("billing");
+
+  if (billing === "success") {
+    return <p className="mt-5 text-sm text-[var(--rb-accent)]">결제가 완료되었습니다. 구독 상태 반영까지 최대 1분 정도 소요될 수 있습니다.</p>;
+  }
+  if (billing === "cancel") {
+    return <p className="mt-5 text-sm text-[var(--rb-warning)]">결제가 취소되었습니다. 다시 시도하실 수 있습니다.</p>;
+  }
+  return null;
 }
 
-export default function PricingContent({ userId, billing }: PricingContentProps) {
+export default function PricingContent() {
   const { locale } = useTranslation();
   const content = getSiteContent(locale).pricing;
+
+  const planSummary = content.plans
+    .map((plan) => {
+      const planName = plan.name === "free" ? "Starter" : plan.name === "basic" ? "Basic" : "Pro";
+      const tier = plan.name === "basic" || plan.name === "pro" ? plan.name : "free";
+      const limit = getGatesForPlan(tier).monthlyAnalysisLimit.toLocaleString("ko-KR");
+      return locale === "en"
+        ? `${planName} ${plan.price} (${limit} analyses/month)`
+        : `${planName} ${plan.price} (월 ${limit}회 분석)`;
+    })
+    .join(", ");
 
   return (
     <main className="pageMain pricingPage pb-8">
       <ShellContainer className="pt-8 md:pt-12">
         <Surface className="px-6 py-7 md:px-8 md:py-9">
           <SectionHeader eyebrow={content.eyebrow} title={content.title} description={content.lead} />
+          <p className="mt-4 text-sm leading-7 text-[var(--rb-muted-strong)]">
+            {locale === "en" ? `ReviewBoost offers 3 plans: ${planSummary}.` : `ReviewBoost 요금제는 ${planSummary} 3가지입니다.`}
+          </p>
           <div className="mt-6 flex flex-wrap gap-3">
             {content.pills.map((pill) => (
               <span
@@ -30,8 +53,9 @@ export default function PricingContent({ userId, billing }: PricingContentProps)
               </span>
             ))}
           </div>
-          {billing === "success" ? <p className="mt-5 text-sm text-[var(--rb-accent)]">결제가 완료되었습니다. 구독 상태 반영까지 최대 1분 정도 소요될 수 있습니다.</p> : null}
-          {billing === "cancel" ? <p className="mt-5 text-sm text-[var(--rb-warning)]">결제가 취소되었습니다. 다시 시도하실 수 있습니다.</p> : null}
+          <Suspense fallback={null}>
+            <BillingNotice />
+          </Suspense>
         </Surface>
       </ShellContainer>
 
@@ -70,9 +94,9 @@ export default function PricingContent({ userId, billing }: PricingContentProps)
                 </div>
                 <div className="mt-7">
                   {plan.name === "basic" ? (
-                    <PricingActions plan="basic" userId={userId ?? undefined} />
+                    <PricingActions plan="basic" />
                   ) : plan.name === "pro" ? (
-                    <PricingActions plan="pro" userId={userId ?? undefined} />
+                    <PricingActions plan="pro" />
                   ) : (
                     <a className="btn btnPrimary w-full justify-center" href="/dashboard">
                       {plan.cta}

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -57,7 +57,7 @@ export function generatePageMetadata(
     title,
     description: record.description,
     keywords,
-    alternates: { canonical: record.canonicalPath },
+    alternates: { canonical: canonicalUrl },
     robots,
     openGraph: {
       type: options.openGraphType ?? "website",

--- a/src/lib/seo/structured-data.ts
+++ b/src/lib/seo/structured-data.ts
@@ -1,9 +1,37 @@
 import { buildCanonicalUrl } from "@/lib/seo/url";
 import { getBaseUrl } from "@/lib/seo/metadata";
+import { getGatesForPlan } from "@/lib/plan_gates";
 import type { SeoBreadcrumb, SeoPageRecord } from "@/lib/seo/page-registry";
 
 function absoluteUrl(path: string) {
   return buildCanonicalUrl(getBaseUrl(), path);
+}
+
+// canonicalizePath percent-encodes "#", so fragments must be appended after URL build
+function organizationId() {
+  return `${absoluteUrl("/")}#organization`;
+}
+
+function websiteId() {
+  return `${absoluteUrl("/")}#website`;
+}
+
+function pricingOffers() {
+  const plans = [
+    { name: "Starter", price: "0", label: "무료 플랜", tier: "free" as const },
+    { name: "Basic", price: "19000", label: "월 19,000원", tier: "basic" as const },
+    { name: "Pro", price: "45000", label: "월 45,000원", tier: "pro" as const }
+  ];
+
+  return plans.map((plan) => ({
+    "@type": "Offer",
+    name: plan.name,
+    description: `${plan.label} — 월 ${getGatesForPlan(plan.tier).monthlyAnalysisLimit.toLocaleString("ko-KR")}회 리뷰 분석`,
+    price: plan.price,
+    priceCurrency: "KRW",
+    availability: "https://schema.org/InStock",
+    url: absoluteUrl("/pricing")
+  }));
 }
 
 function breadcrumbList(items: SeoBreadcrumb[]) {
@@ -21,27 +49,24 @@ function breadcrumbList(items: SeoBreadcrumb[]) {
 function organizationNode() {
   return {
     "@type": "Organization",
-    "@id": absoluteUrl("/#organization"),
+    "@id": organizationId(),
     name: "ReviewBoost",
     url: absoluteUrl("/"),
     logo: absoluteUrl("/icon.svg"),
-    email: "mailto:kwan765@naver.com"
+    email: "kwan765@naver.com",
+    sameAs: ["https://sajangbu.com"]
   };
 }
 
 function websiteNode() {
   return {
     "@type": "WebSite",
-    "@id": absoluteUrl("/#website"),
+    "@id": websiteId(),
     url: absoluteUrl("/"),
     name: "ReviewBoost",
     inLanguage: "ko",
     description:
-      "쿠팡·스마트스토어 리뷰 데이터를 분석하고 부정리뷰 대응, FAQ 작성, 상세페이지 개선 문구까지 연결하는 AI 리뷰 분석 도구",
-    potentialAction: {
-      "@type": "ViewAction",
-      target: absoluteUrl("/help")
-    }
+      "쿠팡·스마트스토어 리뷰 데이터를 분석하고 부정리뷰 대응, FAQ 작성, 상세페이지 개선 문구까지 연결하는 AI 리뷰 분석 도구"
   };
 }
 
@@ -53,7 +78,7 @@ function webpageNode(record: SeoPageRecord) {
     name: record.title,
     description: record.description,
     inLanguage: "ko",
-    isPartOf: { "@id": absoluteUrl("/#website") },
+    isPartOf: { "@id": websiteId() },
     about: record.primaryKeyword
   };
 }
@@ -69,8 +94,6 @@ export function createSoftwareApplicationStructuredData(record: SeoPageRecord) {
   return {
     "@context": "https://schema.org",
     "@graph": [
-      organizationNode(),
-      websiteNode(),
       {
         "@type": "SoftwareApplication",
         "@id": `${absoluteUrl(record.canonicalPath)}#software`,
@@ -87,13 +110,7 @@ export function createSoftwareApplicationStructuredData(record: SeoPageRecord) {
           "상세페이지·CS·FAQ 개선 액션 제안",
           "PDF 리포트 생성"
         ],
-        offers: {
-          "@type": "AggregateOffer",
-          lowPrice: "0",
-          highPrice: "45000",
-          priceCurrency: "KRW",
-          offerCount: "3"
-        }
+        offers: pricingOffers()
       },
       breadcrumbList(record.breadcrumbs)
     ]
@@ -150,6 +167,7 @@ export function createArticleStructuredData(
   options: {
     headline?: string;
     datePublished?: string;
+    image?: string;
   } = {}
 ) {
   const canonicalUrl = absoluteUrl(record.canonicalPath);
@@ -166,13 +184,12 @@ export function createArticleStructuredData(
         datePublished: options.datePublished ?? record.updatedAt,
         dateModified: record.updatedAt,
         author: {
-          "@type": "Organization",
-          name: "ReviewBoost"
+          "@id": organizationId()
         },
         publisher: {
-          "@id": absoluteUrl("/#organization")
+          "@id": organizationId()
         },
-        image: absoluteUrl("/opengraph-image")
+        image: options.image ? absoluteUrl(options.image) : absoluteUrl("/opengraph-image")
       },
       breadcrumbList(record.breadcrumbs)
     ]
@@ -188,29 +205,7 @@ export function createPricingStructuredData(record: SeoPageRecord) {
         "@id": `${absoluteUrl(record.canonicalPath)}#offers`,
         name: "ReviewBoost 요금제",
         url: absoluteUrl(record.canonicalPath),
-        itemListElement: [
-          {
-            "@type": "Offer",
-            name: "Starter",
-            price: "0",
-            priceCurrency: "KRW",
-            url: absoluteUrl("/pricing")
-          },
-          {
-            "@type": "Offer",
-            name: "Basic",
-            price: "19000",
-            priceCurrency: "KRW",
-            url: absoluteUrl("/pricing")
-          },
-          {
-            "@type": "Offer",
-            name: "Pro",
-            price: "45000",
-            priceCurrency: "KRW",
-            url: absoluteUrl("/pricing")
-          }
-        ]
+        itemListElement: pricingOffers()
       },
       breadcrumbList(record.breadcrumbs)
     ]


### PR DESCRIPTION
## 배경
SEO/AEO 감사(5개 영역 병렬)에서 나온 최상위 이슈들을 수정합니다.

## 변경 사항
### 마케팅 페이지 정적화 (SEO+AEO 핵심)
- 루트 레이아웃의 `force-dynamic` + Clerk `auth()` 제거 → 세션 조회를 AppShell의 `/api/navigation-session` 클라이언트 fetch로 이동 (pathname 변경마다 갱신)
- `/pricing`에서 `auth()`/`searchParams` 제거 (billing 배너는 Suspense 내 useSearchParams로) → `/`, `/pricing`, `/blog`, `/features/*`, `/help` 정적 프리렌더
- 효과: CDN 캐시 활성화 + AI 크롤러(GPTBot·PerplexityBot 등)가 요금제 가격·월 한도를 HTML에서 직접 인용 가능

### JSON-LD 스키마
- `@id` 프래그먼트 `%23` 인코딩 버그 수정 (그래프 연결 복구)
- 홈 Organization/WebSite 중복 제거, `email` mailto: 접두사 제거, 비표준 ViewAction 제거
- Offer에 월 분석 한도 추가 — `plan_gates.ts` 연동 (Free 5회/Basic 200회/Pro 1,000회)
- Article author/publisher를 `@id` 참조로, 글별 이미지 반영

### 기타
- robots.txt: noindex 페이지(login/signup/reset-password) disallow 제거 — 차단 시 구글이 noindex를 못 읽는 충돌 해소
- llms.txt: 블로그 글 8건 링크 + 요금제 팩트 추가
- 블로그 상세에 최종 업데이트 날짜 표시, canonical trailing-slash 일치
- CLAUDE.md 정정 (Next.js 15, 실제 플랜 한도)

## 검증
- `npm run build` 통과 — 마케팅 라우트 전부 ○(static)/●(SSG), dashboard/auth는 ƒ 유지
- vitest 10/10 통과 (401 경로·세션 fetch 성공 경로 테스트 추가)
- 프리렌더 HTML에서 요금제 팩트·수정된 JSON-LD 확인
- 독립 코드리뷰 후 회귀 2건(네비 상태 stale, checkout 401 메시지) 수정 완료

## 리뷰에서 알려진 트레이드오프 (수정 불요 판단)
- 정적 HTML은 게스트 상태로 렌더 → 로그인 사용자는 헤더가 fetch 후 전환 (정적화의 일반적 패턴)
- Paddle 토큰/BASE_URL이 빌드 타임에 고정 → env 변경 시 재배포 필요 (Vercel 관행과 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)