### PR TITLE
test(e2e): authenticated Playwright flows via Clerk test user + local CI gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Local CI gate (this repo does not use GitHub Actions). Runs the fast
+# correctness checks before every push. E2E (npm run test:e2e:smoke) is heavier
+# and run manually. Bypass a single push with `git push --no-verify`.
+set -e
+
+echo "[pre-push] typecheck…"
+npm run typecheck
+
+echo "[pre-push] vitest…"
+npx vitest run
+
+echo "[pre-push] ok"

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ node_modules/
 playwright-report/
 .claude/settings.local.json
 .env*
+
+# E2E / test artifacts
+test-results/
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,21 @@ npm run lint         # ESLint (next/core-web-vitals)
 ```
 
 ```bash
-npm run typecheck    # next typegen + tsc --noEmit
-npm test             # source-text guards + full Vitest suite (vitest run)
-npx vitest run       # Vitest unit/component tests directly
+npm run typecheck      # next typegen + tsc --noEmit
+npm test               # source-text guards + full Vitest suite (vitest run)
+npx vitest run         # Vitest unit/component tests directly
+npm run test:e2e:smoke # Playwright E2E (starts its own dev server on 3001)
 ```
 
-Tests use **Vitest** (unit + jsdom component/route tests under `src/**/*.test.ts(x)` and `tests/**`). `npm test` runs the two legacy source-text guard scripts and then `vitest run`, so CI's `quality` job (`lint` → `typecheck` → `test`) executes the whole suite. CI also runs `build`, the tsx user-story matrix (`ci:user-story-matrix`), contract checks (`ci:contracts`), and a security scan (`ci:security`); Playwright E2E runs separately.
+Tests use **Vitest** (unit + jsdom component/route tests under `src/**/*.test.ts(x)` and `tests/**`) and **Playwright** (`tests/e2e.spec.ts`). `npm test` runs the two legacy source-text guard scripts and then `vitest run`.
+
+### CI / gating (no GitHub Actions)
+
+GitHub Actions is **disabled** on this repo, so `.github/workflows/ci.yml` does not run — the **Vercel** build (`next build` on every push/PR) and **local** checks are the gates. Before pushing, run `npm run typecheck && npx vitest run` (and `npm run test:e2e:smoke` for UI changes). An opt-in local pre-push hook is provided at `.githooks/pre-push` (runs typecheck + vitest); enable it per-clone with `git config core.hooksPath .githooks`.
+
+### E2E (Playwright)
+
+`playwright.config.ts` loads `.env.local`, forces `NODE_ENV=development` (the file pins `production`, which would make the dev Edge middleware disallow `eval`), and starts `DEV_FORCE_ANALYSIS_MODE=heuristic npm run dev`. Authenticated dashboard tests sign in as a dedicated Clerk **test user** via `@clerk/testing` (backend ticket sign-in — no password needed at runtime). One-time setup: create the test user with `node scripts/e2e/create-clerk-test-user.mjs` (needs a `sk_test_` `CLERK_SECRET_KEY`; writes `E2E_CLERK_USER_EMAIL`/`E2E_CLERK_USER_PASSWORD` to gitignored `.env.local`). Authenticated tests `test.skip` when `E2E_CLERK_USER_EMAIL` is absent. `tests/global.setup.ts` fetches the Clerk testing token and warms route compilation.
 
 ## Tech Stack
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@clerk/testing": "^2.2.7",
         "@playwright/test": "^1.58.2",
         "@storybook/addon-essentials": "^8.6.12",
         "@storybook/nextjs": "^8.6.12",
@@ -1905,12 +1906,12 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.5.0.tgz",
-      "integrity": "sha512-g1bjzqj7/mb6rnrQ5zr+ybjpilTIWADaCoHE1HnEAjQfbcdfn3gb9PPX0wJ1KWw8OOQEQYSjzXPzvofEB1j+ww==",
+      "version": "3.11.4",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.11.4.tgz",
+      "integrity": "sha512-w4SaKIMuXYJY9bU70ZHxNZtam0GYWlT0IIN7QHsZ1p9LC+v6P/JyHqVK9PNiXjcjVTZymMxkm5d9N6//9MBDzg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.15.0",
+        "@clerk/shared": "^4.25.2",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -1969,9 +1970,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.15.0.tgz",
-      "integrity": "sha512-uX8nfLb69m8mA6KWKWfuPSwoVNDRyUdufeCeTEZsdZxbRUsEYT/c0KWFN28IOQCtK09tpVtzrUHvW44v5Dc5OA==",
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.2.tgz",
+      "integrity": "sha512-v7zgDh0eVLl3KzRHbKYTsPQ+4Xcx8A2oiU5iZ9WhME024WudwkjjPJRK12RycY0VA1Sj8i4Pi5zEpecqB/gp1Q==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
@@ -1991,6 +1992,33 @@
           "optional": true
         },
         "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@clerk/testing/-/testing-2.2.7.tgz",
+      "integrity": "sha512-JbdPgoivA9I5dNQ5mbAyPvwI7mtFA6h4Bj1v4RUVMimA4iZpAIgtoiWTzUe9vQD+nvpL43Wf9YvL0khf80fivQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.11.4",
+        "@clerk/shared": "^4.25.2",
+        "dotenv": "17.2.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1",
+        "cypress": "^13 || ^14 || ^15"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": true
+        },
+        "cypress": {
           "optional": true
         }
       }
@@ -9618,6 +9646,19 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@clerk/testing": "^2.2.7",
     "@playwright/test": "^1.58.2",
     "@storybook/addon-essentials": "^8.6.12",
     "@storybook/nextjs": "^8.6.12",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,16 @@
+import { loadEnvConfig } from '@next/env';
 import { defineConfig, devices } from '@playwright/test';
+
+// Load .env.local (Clerk keys + E2E test-user creds) into the test process.
+// .env.local pins NODE_ENV=production; force development so the spawned `next dev`
+// webServer serves a dev Edge bundle (a production bundle disallows eval in
+// middleware → "Code generation from strings disallowed").
+loadEnvConfig(process.cwd());
+process.env.NODE_ENV = "development";
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: ['**/e2e.spec.ts'],
+  testMatch: ['**/e2e.spec.ts', '**/global.setup.ts'],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -13,16 +21,17 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   projects: [
+    { name: 'setup', testMatch: /global\.setup\.ts/ },
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup'],
     },
   ],
   webServer: {
-    // Run without Clerk so auth middleware is inactive and /dashboard renders in
-    // its degraded (no-auth) mode — the mode these UI-shell E2E tests target.
-    // (Authenticated flows are out of scope until test-auth infra exists.)
-    command: 'CLERK_SECRET_KEY= NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY= npm run dev',
+    // Run with Clerk enabled (real auth for the authenticated dashboard tests) and
+    // force heuristic analysis so the analyze flow needs no OpenAI calls.
+    command: 'DEV_FORCE_ANALYSIS_MODE=heuristic npm run dev',
     url: 'http://127.0.0.1:3001',
     reuseExistingServer: !process.env.CI,
   },

--- a/scripts/e2e/create-clerk-test-user.mjs
+++ b/scripts/e2e/create-clerk-test-user.mjs
@@ -1,0 +1,53 @@
+// Creates (or resets the password of) a dedicated Clerk test user for authenticated
+// E2E, then writes its credentials to .env.local (gitignored). Idempotent.
+//
+// Usage: CLERK_SECRET_KEY must be a dev (sk_test_) key. Run from the repo root:
+//   export $(grep -E '^CLERK_SECRET_KEY=' .env.local | sed 's/^/ /') && node scripts/e2e/create-clerk-test-user.mjs
+// or simply: node -r dotenv/config scripts/e2e/create-clerk-test-user.mjs dotenv_config_path=.env.local
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+
+const SK = process.env.CLERK_SECRET_KEY;
+if (!SK || !SK.startsWith("sk_test_")) {
+  console.error("Refusing to run: CLERK_SECRET_KEY missing or not a test (sk_test_) key.");
+  process.exit(1);
+}
+const EMAIL = process.env.E2E_CLERK_USER_EMAIL || "e2e+clerk_test@reviewboost.co.kr";
+const PASSWORD = randomBytes(18).toString("base64").replace(/[+/=]/g, "") + "aA1!";
+const API = "https://api.clerk.com/v1";
+const H = { Authorization: `Bearer ${SK}`, "Content-Type": "application/json" };
+
+async function findUser() {
+  const r = await fetch(`${API}/users?email_address=${encodeURIComponent(EMAIL)}`, { headers: H });
+  if (!r.ok) throw new Error(`list users failed: ${r.status} ${await r.text()}`);
+  const arr = await r.json();
+  return Array.isArray(arr) && arr.length ? arr[0] : null;
+}
+
+async function main() {
+  let user = await findUser();
+  if (user) {
+    const r = await fetch(`${API}/users/${user.id}`, {
+      method: "PATCH", headers: H,
+      body: JSON.stringify({ password: PASSWORD, skip_password_checks: true })
+    });
+    if (!r.ok) throw new Error(`patch failed: ${r.status} ${await r.text()}`);
+    console.log(`Reset password for existing test user (${user.id}).`);
+  } else {
+    const r = await fetch(`${API}/users`, {
+      method: "POST", headers: H,
+      body: JSON.stringify({ email_address: [EMAIL], password: PASSWORD, skip_password_checks: true })
+    });
+    if (!r.ok) throw new Error(`create failed: ${r.status} ${await r.text()}`);
+    user = await r.json();
+    console.log(`Created test user (${user.id}).`);
+  }
+
+  const path = ".env.local";
+  let body = existsSync(path) ? readFileSync(path, "utf8") : "";
+  body = body.split("\n").filter((l) => !/^E2E_CLERK_USER_(EMAIL|PASSWORD)=/.test(l)).join("\n").replace(/\n+$/, "");
+  body += `\nE2E_CLERK_USER_EMAIL=${EMAIL}\nE2E_CLERK_USER_PASSWORD=${PASSWORD}\n`;
+  writeFileSync(path, body);
+  console.log(`Wrote E2E_CLERK_USER_EMAIL / E2E_CLERK_USER_PASSWORD to ${path} (email: ${EMAIL}).`);
+}
+main().catch((e) => { console.error(String(e)); process.exit(1); });

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,22 +1,37 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
 
-test.describe("ReviewBoost E2E Tests", () => {
+const E2E_EMAIL = process.env.E2E_CLERK_USER_EMAIL;
+
+// Signs in the dedicated Clerk test user via a backend-issued ticket (no password
+// needed). Requires E2E_CLERK_USER_EMAIL + Clerk keys in the environment.
+async function signInTestUser(page: Page) {
+  await setupClerkTestingToken({ page });
+  await page.goto("/");
+  // Wait for Clerk to finish loading before signing in — the first navigation
+  // after a cold dev compile can otherwise race window.Clerk.
+  await clerk.loaded({ page });
+  await clerk.signIn({ page, emailAddress: E2E_EMAIL! });
+}
+
+test.describe("ReviewBoost E2E — public pages", () => {
   test("homepage loads successfully", async ({ page }) => {
     await page.goto("/");
     await expect(page).toHaveTitle(/AI 리뷰 분석 툴/);
   });
 
-  test("login page loads", async ({ page }) => {
-    // Auth pages now render the Clerk <SignIn/> widget, which only mounts when
-    // Clerk is configured. In the local (no-Clerk) run the widget can't mount,
-    // so we assert the route resolves and renders its SEO title.
+  test("login page renders the Clerk sign-in widget", async ({ page }) => {
+    await setupClerkTestingToken({ page });
     await page.goto("/login");
     await expect(page).toHaveTitle(/로그인/);
+    await expect(page.locator(".cl-rootBox").first()).toBeVisible();
   });
 
-  test("signup page loads", async ({ page }) => {
+  test("signup page renders the Clerk sign-up widget", async ({ page }) => {
+    await setupClerkTestingToken({ page });
     await page.goto("/signup");
     await expect(page).toHaveTitle(/회원가입/);
+    await expect(page.locator(".cl-rootBox").first()).toBeVisible();
   });
 
   test("pricing page loads", async ({ page }) => {
@@ -45,9 +60,24 @@ test.describe("ReviewBoost E2E Tests", () => {
         !e.includes("cdn.paddle.com") &&
         !e.includes("paddle.css") &&
         !e.includes("profitwell") &&
-        !e.includes("googletagmanager")
+        !e.includes("googletagmanager") &&
+        !e.includes("clerk.")
     );
     expect(criticalErrors).toHaveLength(0);
+  });
+});
+
+test.describe("ReviewBoost E2E — authenticated dashboard", () => {
+  test.skip(!E2E_EMAIL, "E2E_CLERK_USER_EMAIL not set — skipping authenticated flows");
+
+  test.beforeEach(async ({ page }) => {
+    await signInTestUser(page);
+  });
+
+  test("authenticated user reaches the protected dashboard (no redirect)", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.getByRole("heading", { name: "홈", level: 1 })).toBeVisible();
   });
 
   test("dashboard shell navigation is operable (desktop)", async ({ page }) => {

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -1,0 +1,15 @@
+import { clerkSetup } from "@clerk/testing/playwright";
+import { test as setup } from "@playwright/test";
+
+// Fetches a Clerk Testing Token (bypasses bot detection) for the dev instance.
+// Requires CLERK_SECRET_KEY + a publishable key in the environment (loaded from
+// .env.local by playwright.config.ts).
+setup("clerk global setup", async ({ page }) => {
+  await clerkSetup({ publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY });
+
+  // Warm up dev-mode compilation of the routes the tests hit so the first real
+  // test doesn't race a cold Webpack compile (which can exceed Clerk's load wait).
+  for (const path of ["/", "/dashboard", "/dashboard/analyze", "/pricing"]) {
+    await page.goto(path, { waitUntil: "domcontentloaded" }).catch(() => {});
+  }
+});


### PR DESCRIPTION
## 요약
인증 E2E를 실제 Clerk 테스트 계정으로 복원하고, GitHub Actions를 쓰지 않는 방향에 맞춰 로컬 게이트를 문서화했습니다. 앱 런타임 코드 변경 없음(테스트·설정·문서·스크립트만).

## 인증 E2E (Playwright)
- `@clerk/testing` 추가. 전용 Clerk **테스트 계정**으로 백엔드 티켓 로그인(런타임 비밀번호 불필요) → 보호된 `/dashboard` 플로우 검증.
- 자격증명은 gitignore된 `.env.local`에만. `scripts/e2e/create-clerk-test-user.mjs`로 재생성 가능(멱등, `sk_test_` 필요).
- `tests/global.setup.ts`: Clerk 테스팅 토큰 취득 + 라우트 컴파일 워밍(첫 인증 테스트의 콜드 컴파일 레이스 방지).
- `playwright.config.ts`: `.env.local` 로드 + `NODE_ENV=development` 강제(파일이 production으로 고정 → dev Edge 미들웨어가 eval 금지 에러) + `DEV_FORCE_ANALYSIS_MODE=heuristic`.
- `e2e.spec.ts`: 11개(공개 5 + 인증 대시보드 6). 인증 블록은 `E2E_CLERK_USER_EMAIL` 없으면 skip.

## CI 게이트 (GitHub Actions 미사용)
- Actions 비활성 유지. 게이트 = **Vercel 빌드 + 로컬 체크**.
- 옵트인 `.githooks/pre-push`(typecheck + vitest) 추가 — `git config core.hooksPath .githooks`로 각자 활성화(자동 활성화 안 함).
- `test-results/`, `.playwright-mcp/` gitignore.

## 검증
로컬: 유닛 203/203 · E2E 11/11(콜드/웜 재현) · typecheck 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)